### PR TITLE
解决微信分享成功后没有回调方法的问题

### DIFF
--- a/ios/RCTWeChatAPI/RCTWeChatAPI.m
+++ b/ios/RCTWeChatAPI/RCTWeChatAPI.m
@@ -102,12 +102,14 @@ RCT_EXPORT_METHOD(shareToTimeline:(NSDictionary *)data
                   :(RCTResponseSenderBlock)callback)
 {
     [self shareToWeixinWithData:data scene:WXSceneTimeline callback:callback];
+     callback(@[[NSNull null]]);
 }
 
 RCT_EXPORT_METHOD(shareToSession:(NSDictionary *)data
                   :(RCTResponseSenderBlock)callback)
 {
     [self shareToWeixinWithData:data scene:WXSceneSession callback:callback];
+     callback(@[[NSNull null]]);
 }
 
 RCT_EXPORT_METHOD(pay:(NSDictionary *)data


### PR DESCRIPTION
当接口需要根据分享是否成功进行后续逻辑处理时，原有的代码没有增加回调方法，导致js里面的waitForResponse不生效。
